### PR TITLE
Remove manual last updated notes

### DIFF
--- a/acceptable-use-policy.md
+++ b/acceptable-use-policy.md
@@ -3,12 +3,6 @@ title: "Acceptable Use Policy"
 sidebar_position: 4
 ---
 
-:::info Last updated
-
-July 17, 2023
-
-:::
-
 This Acceptable Use Policy sets out a list of acceptable and unacceptable conduct for our Services. If we believe a violation of the policy is deliberate, repeated or presents a credible risk of harm to other users, our customers, the Services or any third parties, we may suspend or terminate your access. This policy may change as Retool grows and evolves, so please check back regularly for updates and changes. Capitalized terms used below but not defined in this policy have the meaning set forth in the User Terms of Service.
 
 Do:

--- a/customer-specific-supplement.md
+++ b/customer-specific-supplement.md
@@ -3,12 +3,6 @@ title: "Customer-Specific Supplement"
 sidebar_position: 3
 ---
 
-:::info Last updated
-
-July 17, 2023
-
-:::
-
 The terms of the Customer-Specific Supplement ("Customer-Specific Supplement") below supplement and amend Customer's Contract (as defined in our [Customer Terms of Service](https://docs.retool.com/page/customer-terms)) if Customer falls into the corresponding category of Customer. If there is any conflict between the Customer-Specific Supplement and the Contract, the applicable terms in the Customer-Specific Supplement will prevail. Nothing in this Customer-Specific Supplement makes us a government contractor for any federal, state, local, or foreign government. 
 
 ## I. U.S. Government Customers

--- a/customer-terms-of-service.md
+++ b/customer-terms-of-service.md
@@ -3,12 +3,6 @@ title: Customer Terms of Service
 sidebar_position: 1
 ---
 
-:::info Last updated
-
-July 17, 2023
-
-:::
-
 These Customer Terms of Service (the "Customer Terms") describe your rights and responsibilities when using our developer tools and platform (the "Services"). Please read them carefully. If you are a Customer (defined below), these Customer Terms govern your access and use of our Services. If you are an individual that a Customer is inviting to use the Services, the [User Terms of Service](https://docs.retool.com/page/user-terms) (the "User Terms") govern your access and use of the Services. 
 
 ## THE CONTRACT

--- a/data-request-policy.md
+++ b/data-request-policy.md
@@ -3,12 +3,6 @@ title: "Data Request Policy"
 sidebar_position: 7
 ---
 
-:::info Last updated
-
-July 17, 2023
-
-:::
-
 Not unlike other technology companies, Retool receives requests from users and government agencies to disclose or delete data other than in the ordinary operation and provision of the Services. This Data Request Policy addresses those issues and outlines Retool's policies and procedures for responding to such requests for Customer Data. Any capitalized terms used in this Data Request Policy that are not defined will have the meaning set forth in the [Customer Terms of Service](https://docs.retool.com/page/customer-terms). In the event of any inconsistency between the provisions of this Data Request Policy and the Customer Terms of Service, the provisions of the Customer Terms of Service will control.
 
 ## Requests for Customer Data by Individuals

--- a/dmca-policy.md
+++ b/dmca-policy.md
@@ -3,12 +3,6 @@ title: "DMCA Policy"
 sidebar_position: 8
 ---
 
-:::info Last updated
-
-July 17, 2023
-
-:::
-
 We take the intellectual property rights of others seriously and require that our Customers and their Authorized Users do the same. The Digital Millennium Copyright Act established a process for addressing claims of copyright infringement that we have implemented for Retool services. If you **own a copyright or have authority to act on behalf of a copyright owner** and want to report a claim that a third party is infringing that material on or through a Retool service, please send a notice to our copyright agent that includes all of the items below and we will expeditiously take appropriate action:
 
 - A description of the copyrighted work that you claim is being infringed; 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -3,12 +3,6 @@ title: "Privacy Policy"
 sidebar_position: 9
 ---
 
-:::info Last updated
-
-July 17, 2023
-
-:::
-
 This Privacy Policy explains our practices regarding the collection, use and disclosure of the information we process to provide our Services. This Privacy Policy does not apply to any third-party websites, services or applications, even if they are accessible through our Services. 
 
 When we refer to "Retool" ("we", "our" or "us"), we mean the Retool entity that acts as the controller or processor of your information, Retool, Inc. Please refer to the section titled 'Identity of the Data Controller and Data Processor' for more information. 

--- a/security.md
+++ b/security.md
@@ -3,12 +3,6 @@ title: "Security practices"
 sidebar_position: 5
 ---
 
-:::info Last updated
-
-August 14, 2023
-
-:::
-
 We take the security of your data very seriously at Retool. If you have additional questions regarding security, we are happy to answer them. Please write to [security@retool.com](mailto:security@retool.com) and we will respond as quickly as we can. This Security Practices page describes the administrative, technical and physical controls applicable to Retool.
 
 ## Hosting, Architecture, and configurations

--- a/subprocessors.md
+++ b/subprocessors.md
@@ -3,12 +3,6 @@ title: "Subprocessors"
 sidebar_position: 6
 ---
 
-:::info Last updated
-
-June 28, 2023
-
-:::
-
 To support delivery of our Services, Retool, Inc. (or one of its Affiliates listed below), may engage and use data processors with access to certain Customer Data (each, a "Subprocessor"). This page provides important information about the identity, location and role of each Subprocessor. Terms used on this page but not defined have the meaning set forth in the [Customer Terms of Service](https://retool.com/tos.pdf) (or if applicable, the superseding written agreement between Customer and Retool or a Retool affiliate(s)) (the "Agreement").
 
 ## Third Parties

--- a/user-terms-of-service.md
+++ b/user-terms-of-service.md
@@ -3,12 +3,6 @@ title: User Terms of Service
 sidebar_position: 2
 ---
 
-:::info Last updated
-
-July 17, 2023
-
-:::
-
 These User Terms of Service (the "User Terms") govern your access and use of our developer tools and platform (the "Service"). Please read them carefully. Even though you are signing onto an organization's account, these User Terms apply to you as a user of the Services. 
 
 ## THE TERMS


### PR DESCRIPTION
The last updated date is now automatically included at the bottom of all docs, pulled from Git logs. This change removes the manually added last updated dates.