### PR TITLE
remove mention of email addresses being sent to temporal

### DIFF
--- a/security.md
+++ b/security.md
@@ -25,7 +25,7 @@ When you connect a Custom App to a database provided by Retool, Retool stores Cu
 
 Note that if you enable [query or workflow caching](https://docs.retool.com/docs/caching-in-retool), Customer Data is temporarily cached by Retool for the specified cache duration. You can invalidate a query's cache—or disable query and workflow caching entirely—at any time.
 
-When you elect to deploy self-hosted Workflows with a Retool-managed Temporal cluster, only encrypted internal Workflow ids, Workflow block names, and the email addresses of the users enqueuing Workflows are stored in Temporal Technologies’ Cloud offering; no other Customer Data, code or query contents are sent to Temporal Cloud. All Customer Data is encrypted with your private encryption key prior to leaving your own VPC or VPN. The encryption key is defined within your infrastructure and is never sent to Retool or Temporal Technologies. Customer Data is stored in Temporal Cloud for 14 days by default, this retention period is configurable by submitting a request to Retool.
+When you elect to deploy self-hosted Workflows with a Retool-managed Temporal cluster, only encrypted internal Workflow ids and Workflow block names are stored in Temporal Technologies’ Cloud offering; no other Customer Data, code or query contents are sent to Temporal Cloud. All Customer Data is encrypted with your private encryption key prior to leaving your own VPC or VPN. The encryption key is defined within your infrastructure and is never sent to Retool or Temporal Technologies. Customer Data is stored in Temporal Cloud for 14 days by default, this retention period is configurable by submitting a request to Retool.
 
 ## Confidentiality and security controls
 


### PR DESCRIPTION
With 3.33 we no longer send the email addresses of the user that enqueued the workflow. Updated the text to remove mention of that data being sent. 

PR that does this for reference: https://github.com/tryretool/retool_development/pull/39492